### PR TITLE
Sanitize file name for addContentToFile and addImageToAssets

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -120,6 +120,7 @@ export default class MoviePlugin extends Plugin {
 			});
 			console.log(response);
 			const movie = response.json;
+			movie.Title = movie.Title.replace(/[/\\?%*:|"<>]/g, '-');
 			return movie;
 		} catch (e) {
 			new Notice("Movie not found.");


### PR DESCRIPTION
Some movies have title with illegal characters for a filename. Sanitizing the title fixes the issue.